### PR TITLE
Fix parser.

### DIFF
--- a/src/VM/Parser.hs
+++ b/src/VM/Parser.hs
@@ -133,6 +133,6 @@ parseFile :: Parser (CPU Int, [Instruction Int])
 parseFile = do
     cpu <- parseConfig
     skipSpace
-    instructions <- many $ parseInst <* endOfLine
-    -- endOfInput
+    instructions <- many $ parseInst
+    endOfInput
     return (cpu, instructions)


### PR DESCRIPTION
`skipSpace` consumes whitespace, leading to strange `endOfLine` behavior. Removing this and adding 'endOfInput' leads to the expected parser output (at least for `test.hasm`).
